### PR TITLE
Handle UTF-8 file encoding

### DIFF
--- a/lib/__tests__/asset.js
+++ b/lib/__tests__/asset.js
@@ -5,7 +5,7 @@ describe("Asset", () => {
     const asset = new Asset("./lib/__tests__/llama.svg", {}, { rootDir: __dirname });
 
     asset.load().then((pluginOutput)=>{
-      expect(pluginOutput).toEqual(`module.exports = '<svg viewBox="0 0 98 115"><text>llama</text></svg>';`)
+      expect(pluginOutput).toEqual(`module.exports = '<svg viewBox="0 0 98 115"><text>llaméaa</text></svg>';`)
       done()
     })
 

--- a/lib/__tests__/llama.svg
+++ b/lib/__tests__/llama.svg
@@ -2,5 +2,5 @@
 <!-- Generator: Adobe Illustrator 22.0.1, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
 <svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
 	 viewBox="0 0 98 115" style="enable-background:new 0 0 98 115;" xml:space="preserve">
-<text>llama</text>
+<text>llaméaa</text>
 </svg>

--- a/lib/asset.js
+++ b/lib/asset.js
@@ -9,7 +9,7 @@ const { read } = require("./utils");
 
 class InlineSvgAsset extends JSAsset {
   async load() {
-    const file = read(this.name, "binary");
+    const file = read(this.name);
 
     const svgo = new svg({
       plugins: [


### PR DESCRIPTION
Using [`binary`](https://github.com/albinotonnina/parcel-plugin-inlinesvg/blob/master/lib/asset.js#L12) causes encoding problems with accented characters.
