### PR TITLE
fixed the demo link

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -9,6 +9,7 @@ A parcel plugin that enables inline svg support
 <p align="center">
   <img src="https://img.ziggi.org/FkLzuHwv.png" />
 </p>
+
 [demo](https://parcel-inlinsvg.now.sh/)
 
 ## Installation


### PR DESCRIPTION
it needs a newline between it and the raw html to be interpreted as its own markdown block