### PR TITLE
Don't use backticks in output

### DIFF
--- a/lib/asset.js
+++ b/lib/asset.js
@@ -27,7 +27,7 @@ class InlineSvgAsset extends Asset {
   generate() {
     // Send to JS bundler
     return {
-      'js': `module.exports = \`${this.code}\``
+      'js': `module.exports = '${this.code.replace("'", "&#39;")}'`
     };
   }
 }


### PR DESCRIPTION
Older browsers and bundlers don't like template literals. It should be safe to use single quotes instead, as svgo normalises attribute quotes to `"`, and we can replace any others with `&#39;`